### PR TITLE
Make "isUserTrusted" depend on whether InMemory or Persistent mode is on

### DIFF
--- a/server/src/main/scala/data/InMemoryUserCache.scala
+++ b/server/src/main/scala/data/InMemoryUserCache.scala
@@ -1,15 +1,22 @@
 package data
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.collection.concurrent.TrieMap
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scalac.octopusonwire.shared.domain.{UserInfo, UserId}
+import scalac.octopusonwire.shared.domain.{UserId, UserInfo}
 
 class InMemoryUserCache extends UserCache {
   private val tokenCache = TrieMap[String, UserId]()
   private val userCache = TrieMap[UserId, UserInfo]()
 
   private val userFriends = TrieMap[UserId, Set[UserId]]()
+
+  val trustedUsers: mutable.Set[UserId] = mutable.Set.empty
+
+  override def isUserTrusted(id: UserId): Future[Boolean] = Future {
+    trustedUsers contains id
+  }
 
   override def getUserInfo(id: UserId): Future[Option[UserInfo]] = Future {
     userCache.get(id)

--- a/server/src/main/scala/data/PersistentUserCache.scala
+++ b/server/src/main/scala/data/PersistentUserCache.scala
@@ -1,12 +1,14 @@
 package data
 
-import domain.{TokenPairs, UserFriendPairs, Users}
+import domain.{TrustedUsers, TokenPairs, UserFriendPairs, Users}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scalac.octopusonwire.shared.domain.{UserId, UserInfo}
 
 class PersistentUserCache extends UserCache {
+
+  override def isUserTrusted(id: UserId): Future[Boolean] = TrustedUsers.isUserTrusted(id)
 
   override def getUserInfo(id: UserId): Future[Option[UserInfo]] = Users.userById(id)
 

--- a/server/src/main/scala/data/UserCache.scala
+++ b/server/src/main/scala/data/UserCache.scala
@@ -8,6 +8,8 @@ import scala.concurrent.Future
 import scalac.octopusonwire.shared.domain.{UserInfo, UserId}
 
 trait UserCache {
+  def isUserTrusted(id: UserId): Future[Boolean]
+
   def getUserInfo(id: UserId): Future[Option[UserInfo]]
 
   def saveUserInfo(userInfo: UserInfo): Unit

--- a/server/src/main/scala/services/ApiService.scala
+++ b/server/src/main/scala/services/ApiService.scala
@@ -110,7 +110,7 @@ class ApiService(tokenOpt: Option[String], userId: Option[UserId],
     )
 
   private def getUserReputationFuture(id: UserId): Future[UserReputationInfo] = {
-    val isTrustedFuture = TrustedUsers.isUserTrusted(id)
+    val isTrustedFuture = userCache.isUserTrusted(id)
     val canAddFuture = eventSource.countPastJoinsBy(id).map { rep =>
       UserReputationInfo(rep.toLong, PastJoinsRequiredToAddEvents)
     }


### PR DESCRIPTION
Previously, ApiService used TrustedUsers.isUserTrusted directly, which caused the event addition tests to fail.
